### PR TITLE
Added libffi dependency to fix build

### DIFF
--- a/summit/tensorflow/1.6.0/Dockerfile.python3
+++ b/summit/tensorflow/1.6.0/Dockerfile.python3
@@ -24,5 +24,6 @@ RUN wget https://github.com/olcf/container-recipes/raw/master/summit/tensorflow/
 
 RUN ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1 && \
     ldconfig /usr/local/cuda/lib64/stubs && \
+    yum -y install libffi-devel.ppc64le && \
     pip3 install horovod && \
     ldconfig


### PR DESCRIPTION
horovod depends on libffi.  However, this recipe will not build as-is because that library is not installed.  This explicitly installs the dependency such that the build can complete.